### PR TITLE
    make clean removes .aux from chp/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,5 @@ clean:
                *.lot \
                *.out \
                *.toc \
-	       *.run.xml
-
+	       *.run.xml \
+	       chp/*.aux


### PR DESCRIPTION
    .aux files were left in the chp/ file after make clean was run.
    This fixes that so all *.aux files are removed.